### PR TITLE
fix: CounterState None crash, EncounterEnd cycle, Date dict, UV resolution

### DIFF
--- a/src/synthea/engine/logic.py
+++ b/src/synthea/engine/logic.py
@@ -138,19 +138,25 @@ class Logic:
         """Test a date condition."""
         operator_str = condition.get('operator', '==')
         
-        # Parse the date
-        date_str = condition.get('date')
-        if not date_str:
+        # Parse the date — 'date' may be an ISO string, a dict of {year,month,day},
+        # or absent (year/month/day as top-level keys).
+        date_val = condition.get('date')
+        if isinstance(date_val, dict):
+            year = date_val.get('year', condition.get('year'))
+            month = date_val.get('month', condition.get('month', 1))
+            day = date_val.get('day', condition.get('day', 1))
+            if not year:
+                return False
+            target_date = datetime(int(year), int(month), int(day))
+        elif isinstance(date_val, str):
+            target_date = datetime.fromisoformat(date_val.replace('Z', '+00:00'))
+        else:
             year = condition.get('year')
             month = condition.get('month', 1)
             day = condition.get('day', 1)
-            if year:
-                target_date = datetime(year, month, day)
-            else:
+            if not year:
                 return False
-        else:
-            # Parse ISO date string
-            target_date = datetime.fromisoformat(date_str.replace('Z', '+00:00'))
+            target_date = datetime(int(year), int(month), int(day))
         
         return Logic._compare_dates(time, operator_str, target_date)
     

--- a/src/synthea/engine/state.py
+++ b/src/synthea/engine/state.py
@@ -300,7 +300,7 @@ class CounterState(State):
             raw = person.attributes.get(attribute, 0)
             try:
                 current = int(raw)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
                 current = 0
             if action == 'increment':
                 person.attributes[attribute] = current + 1

--- a/src/synthea/engine/state.py
+++ b/src/synthea/engine/state.py
@@ -297,7 +297,11 @@ class CounterState(State):
         action = self.definition.get('action', 'increment')
         
         if attribute:
-            current = person.attributes.get(attribute, 0)
+            raw = person.attributes.get(attribute, 0)
+            try:
+                current = int(raw)
+            except (TypeError, ValueError):
+                current = 0
             if action == 'increment':
                 person.attributes[attribute] = current + 1
             elif action == 'decrement':

--- a/src/synthea/engine/state.py
+++ b/src/synthea/engine/state.py
@@ -335,15 +335,29 @@ class EncounterState(State):
 
 class EncounterEndState(State):
     """A state that ends a healthcare encounter."""
-    
+
     def run(self, person: 'Person', time: datetime) -> bool:
-        """End the current encounter."""
+        """End the current encounter and yield to the next time step.
+
+        Returning False (yield) prevents modules that loop back to an Encounter
+        state immediately after EncounterEnd from cycling indefinitely within a
+        single time step — matching the Java Synthea engine's behaviour where
+        ending an encounter naturally breaks the within-step loop.
+        """
+        end_key = f'{self.module.name}.{self.name}_ended_at'
+        last_ended = person.attributes.get(end_key)
+
+        if last_ended == time:
+            # Already ended this encounter at this time step; yield again.
+            return False
+
         if hasattr(person, 'record') and 'current_encounter' in person.attributes:
             encounter = person.attributes['current_encounter']
             person.record.encounter_end(encounter, time)
             del person.attributes['current_encounter']
-        
-        return True
+
+        person.attributes[end_key] = time
+        return False
 
 
 class ConditionOnsetState(State):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -118,6 +118,28 @@ class TestStates:
         dec_state.run(person, datetime.now())
         assert person.attributes['counter'] == 1
     
+    def test_counter_state_none_attribute(self):
+        """Counter state must not crash when the attribute is None or non-numeric."""
+        module = Module('test')
+        inc_def = {'type': 'Counter', 'attribute': 'counter', 'action': 'increment'}
+        dec_def = {'type': 'Counter', 'attribute': 'counter', 'action': 'decrement'}
+        person = Person()
+
+        # Attribute explicitly set to None
+        person.attributes['counter'] = None
+        CounterState(module, 'inc', inc_def).run(person, datetime.now())
+        assert person.attributes['counter'] == 1
+
+        # Attribute set to a string
+        person.attributes['counter'] = 'not_a_number'
+        CounterState(module, 'inc', inc_def).run(person, datetime.now())
+        assert person.attributes['counter'] == 1
+
+        # Attribute set to float('inf') — int() raises OverflowError
+        person.attributes['counter'] = float('inf')
+        CounterState(module, 'dec', dec_def).run(person, datetime.now())
+        assert person.attributes['counter'] == -1
+
     def test_guard_state(self):
         """Test Guard state."""
         module = Module('test')


### PR DESCRIPTION
## Summary

Four simulation engine / packaging bugs fixed:

### 1. `CounterState` crashes when attribute is `None` (fixes #9)
`admission` and `postop` modules raised `TypeError: NoneType - int` every time step. Added a `try/except (TypeError, ValueError, OverflowError)` guard that coerces any non-numeric value to `0`.

### 2. `EncounterEnd` causes infinite same-step cycles
`Wellness Encounters`, `Medication Reconciliation`, `MEND Program`, and `Metabolic Syndrome Standards of Care` looped directly from `EncounterEnd` back to `Encounter` with no `Delay`, hitting the 500-iteration cap every weekly step. `EncounterEndState.run()` now returns `False` to yield to the next time step, matching Java Synthea's behaviour.

### 3. `Date` logic condition crashes when `date` field is a dict
`art_sequence_2003_2005` raised `AttributeError: 'dict' has no attribute 'replace'`. `_test_date()` now handles all three forms: ISO string, top-level `year`/`month`/`day` keys, and `{"year": ..., "month": ..., "day": ...}` dict under `date`.

### 4. `uv run synthea` fails with UV dependency resolution error
UV resolves for all Python × platform combinations in `requires-python`. `sbml2python` is unavailable for `python >= 3.15` on `win32`, breaking resolution even on Linux/Python 3.13. Fixed by:
- Narrowing `requires-python` to `>=3.9,<3.14`
- Adding `sys_platform != 'win32'` marker to `sbml2python`
- Updating classifiers and tool targets to match

## Test plan

- [x] `pytest tests/ -q` — 32 tests pass (includes new regression test for CounterState)
- [x] `uv run synthea --help` resolves without error
- [x] `admission` / `postop` run without `TypeError`
- [x] 4 cycle-heavy modules run 52 weekly steps with zero cycle-cap warnings
- [x] `art_sequence_2003_2005` no longer crashes on `Date` conditions