### PR TITLE
fix: exclude win32 from UV dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Examples:
 ## Project Structure
 
 ```
-tietai-symthea/
+tietai-synthea/
 ├── pyproject.toml        # UV-compatible project configuration
 ├── README.md            # This file
 ├── src/synthea/
@@ -580,6 +580,6 @@ This is a Python port of the original [Synthea](https://github.com/syntheticheal
 
 ## Support
 
-- Issues: [GitHub Issues](https://github.com/TIET-AI/tietai-symthea/issues)
-- Discussions: [GitHub Discussions](https://github.com/TIET-AI/tietai-symthea/discussions)
-- Documentation: [Wiki](https://github.com/TIET-AI/tietai-symthea/wiki)
+- Issues: [GitHub Issues](https://github.com/TIET-AI/tietai-synthea/issues)
+- Discussions: [GitHub Discussions](https://github.com/TIET-AI/tietai-synthea/discussions)
+- Documentation: [Wiki](https://github.com/TIET-AI/tietai-synthea/wiki)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,11 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 
+[tool.uv]
+environments = [
+    "sys_platform != 'win32'",
+]
+
 [tool.mypy]
 python_version = "3.9"
 warn_return_any = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "synthea"
 version = "3.0.0"
 description = "Synthetic Patient Population Simulator"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9,<3.14"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "Synthea Contributors"},
@@ -17,10 +17,11 @@ classifiers = [
     "Intended Audience :: Healthcare Industry",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
 
@@ -56,7 +57,7 @@ dev = [
 ]
 
 physiology = [
-    "sbml2python>=0.2.0",
+    "sbml2python>=0.2.0; sys_platform != 'win32'",
     "sympy>=1.9",
 ]
 
@@ -81,7 +82,7 @@ where = ["src"]
 
 [tool.black]
 line-length = 100
-target-version = ['py38']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -90,7 +91,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true


### PR DESCRIPTION
## Problem

`uv run synthea` failed on non-Windows machines because UV resolves
dependencies for all platforms × Python versions by default. The
`sbml2python` package has no wheels for `sys_platform == 'win32'`,
causing:

```
No solution found when resolving dependencies for split
(markers: python_full_version >= '3.11' and python_full_version < '3.14'
 and sys_platform == 'win32')
```

## Root Cause

Two separate issues:
1. `sbml2python` in the `physiology` extra lacked a platform marker,
   so UV attempted to resolve it for win32 where it is unavailable.
2. `requires-python` was `>=3.8`, but `sbml2python` has no release for
   Python ≥ 3.14, so UV still tried to resolve for those versions.

## Fix

- **Cherry-pick** from `fix/counter-state-none-attribute`: narrow
  `requires-python` to `>=3.9,<3.14` and add
  `sbml2python>=0.2.0; sys_platform != 'win32'` marker.
- **New commit**: add `[tool.uv] environments = ["sys_platform != 'win32'"]`
  to tell UV to skip win32 entirely during resolution.
- Correct README repo URL (tietai-symthea → tietai-synthea).

## Test

```bash
uv run synthea -p 100 --state California --city 'San Francisco'
```

Should resolve without error on Linux/macOS.