### PR TITLE
fix: drop sbml2python — package does not exist on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dev = [
 ]
 
 physiology = [
-    "sbml2python>=0.2.0; sys_platform != 'win32'",
     "sympy>=1.9",
 ]
 
@@ -89,11 +88,6 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-
-[tool.uv]
-environments = [
-    "sys_platform != 'win32'",
-]
 
 [tool.mypy]
 python_version = "3.9"


### PR DESCRIPTION
## Problem

`uv run synthea` fails with:

```
Because only sbml2python{sys_platform != 'win32'}<0.2.0 is available
and synthea[physiology] depends on sbml2python{sys_platform != 'win32'}>=0.2.0,
we can conclude that synthea[physiology]'s requirements are unsatisfiable.
```

## Root Cause

`sbml2python` has no releases on PyPI (`curl pypi.org/pypi/sbml2python/json` → 404). UV cannot resolve a dependency that does not exist. Previous PRs tried to gate it with platform markers and `[tool.uv] environments`, but the package is simply missing for all platforms.

`sbml2python` is also never imported anywhere in the source tree — it was a placeholder that was never wired up.

## Fix

- Remove `sbml2python>=0.2.0` from the `physiology` extra
- Remove the `[tool.uv] environments` restriction added solely to work around it
- `physiology` extra now only requires `sympy>=1.9` (which exists on PyPI)