### PR TITLE
fix: resolve submodules by relative path, matching Java Synthea

### DIFF
--- a/src/synthea/engine/module.py
+++ b/src/synthea/engine/module.py
@@ -31,6 +31,7 @@ class Module:
     # Class-level registry of loaded modules
     _modules: Dict[str, 'Module'] = {}
     _module_suppliers: Dict[str, Any] = {}
+    _primary_keys: Set[str] = set()
     
     def __init__(self, name: str):
         """
@@ -167,6 +168,7 @@ class Module:
                         obj != Module):
                         # Create a supplier function for lazy loading
                         cls._module_suppliers[module_name] = lambda m=obj: m()
+                        cls._primary_keys.add(module_name)
                         break
             except ImportError:
                 # Core module not implemented yet
@@ -197,24 +199,36 @@ class Module:
         # Recursively find all .json files
         for json_file in module_path.rglob('*.json'):
             try:
-                cls._load_json_module(json_file)
+                cls._load_json_module(json_file, module_path)
             except Exception as e:
                 print(f"Error loading module {json_file}: {e}")
-    
+
     @classmethod
-    def _load_json_module(cls, filepath: Path):
+    def _load_json_module(cls, filepath: Path, base_path: Path):
         """Load a single JSON module."""
         with open(filepath, 'r', encoding='utf-8') as f:
             definition = json.load(f)
-        
-        # Get module name from the JSON or filename
-        module_name = definition.get('name', filepath.stem)
-        
-        # Create supplier function that creates module from JSON
+
+        json_name = definition.get('name', filepath.stem)
+
+        # Use relative path as the canonical module identity, matching Java
+        # Synthea. This ensures unique state-tracking keys even when multiple
+        # modules share the same JSON name (e.g. heart/cabg/operation and
+        # heart/tavr/operation are both named "operation").
+        relative_path = str(filepath.relative_to(base_path).with_suffix(''))
+        path_key = relative_path.replace(os.sep, '/')
+
         def create_module():
-            return cls._create_from_json(module_name, definition)
-        
-        cls._module_suppliers[module_name] = create_module
+            return cls._create_from_json(path_key, definition)
+
+        # Register by path (primary key, used by CallSubmodule and generator)
+        cls._module_suppliers[path_key] = create_module
+        cls._primary_keys.add(path_key)
+
+        # Also register by JSON name as an alias for convenience, but only
+        # if no other module has already claimed that name
+        if json_name not in cls._module_suppliers:
+            cls._module_suppliers[json_name] = create_module
     
     @classmethod
     def _create_from_json(cls, name: str, definition: Dict[str, Any]) -> 'Module':
@@ -264,13 +278,20 @@ class Module:
     
     @classmethod
     def get_all_modules(cls) -> List[str]:
-        """Get list of all available module names."""
-        return list(cls._module_suppliers.keys())
+        """Get list of top-level module names (excludes submodules in subdirectories).
+
+        Submodules (paths containing '/') are only executed when called via
+        CallSubmodule states, not on every generator timestep. This matches
+        the Java Synthea behaviour.
+        """
+        return sorted(k for k in cls._primary_keys if '/' not in k)
     
     @classmethod
     def clear_cache(cls):
         """Clear the module cache."""
         cls._modules.clear()
+        cls._module_suppliers.clear()
+        cls._primary_keys.clear()
     
     def validate(self) -> List[str]:
         """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -143,7 +143,7 @@ class TestIntegration:
             json.dump(module_def, f)
         
         # Load module
-        Module._load_json_module(module_file)
+        Module._load_json_module(module_file, temp_dir)
         module = Module.get_module("test_module")
         
         assert module is not None
@@ -157,6 +157,142 @@ class TestIntegration:
         assert result is True
         assert person.attributes.get('test_value') == 'success'
     
+    def test_submodule_path_resolution(self, temp_dir):
+        """Test that modules in subdirectories are reachable by relative path."""
+        Module.clear_cache()
+
+        sub_dir = temp_dir / "sub"
+        sub_dir.mkdir()
+        sub_def = {
+            "name": "My Submodule",
+            "states": {
+                "Initial": {
+                    "type": "Initial",
+                    "direct_transition": "Set_Marker"
+                },
+                "Set_Marker": {
+                    "type": "SetAttribute",
+                    "attribute": "sub_ran",
+                    "value": True,
+                    "direct_transition": "Terminal"
+                },
+                "Terminal": {"type": "Terminal"}
+            }
+        }
+        sub_file = sub_dir / "my_sub.json"
+        with open(sub_file, 'w') as f:
+            json.dump(sub_def, f)
+
+        Module._load_json_module(sub_file, temp_dir)
+
+        # Reachable by JSON name
+        assert Module.get_module("My Submodule") is not None
+        Module.clear_cache()
+        Module._load_json_module(sub_file, temp_dir)
+
+        # Reachable by relative path (what CallSubmodule uses)
+        assert Module.get_module("sub/my_sub") is not None
+
+    def test_duplicate_module_names(self, temp_dir):
+        """Test that modules with the same JSON name in different directories
+        get unique identities and don't overwrite each other's state tracking."""
+        Module.clear_cache()
+
+        # Use a unique JSON name to avoid interference from real modules
+        dir_a = temp_dir / "group_a"
+        dir_a.mkdir()
+        dir_b = temp_dir / "group_b"
+        dir_b.mkdir()
+
+        mod_a = {
+            "name": "test_dup",
+            "states": {
+                "Initial": {
+                    "type": "Initial",
+                    "direct_transition": "Step_A",
+                },
+                "Step_A": {
+                    "type": "SetAttribute",
+                    "attribute": "which",
+                    "value": "A",
+                    "direct_transition": "Terminal",
+                },
+                "Terminal": {"type": "Terminal"},
+            },
+        }
+        mod_b = {
+            "name": "test_dup",
+            "states": {
+                "Initial": {
+                    "type": "Initial",
+                    "direct_transition": "Step_B",
+                },
+                "Step_B": {
+                    "type": "SetAttribute",
+                    "attribute": "which",
+                    "value": "B",
+                    "direct_transition": "Terminal",
+                },
+                "Terminal": {"type": "Terminal"},
+            },
+        }
+
+        with open(dir_a / "dup.json", 'w') as f:
+            json.dump(mod_a, f)
+        with open(dir_b / "dup.json", 'w') as f:
+            json.dump(mod_b, f)
+
+        Module._load_json_module(dir_a / "dup.json", temp_dir)
+        Module._load_json_module(dir_b / "dup.json", temp_dir)
+
+        # Both reachable by path
+        a = Module.get_module("group_a/dup")
+        b = Module.get_module("group_b/dup")
+        assert a is not None
+        assert b is not None
+
+        # Unique path-based names prevent state tracking collisions
+        assert a.name == "group_a/dup"
+        assert b.name == "group_b/dup"
+
+        # JSON name alias goes to whichever loaded first (not overwritten)
+        alias = Module.get_module("test_dup")
+        assert alias is not None
+        assert alias.name == "group_a/dup"
+
+    def test_get_all_modules_excludes_submodules(self, temp_dir):
+        """get_all_modules returns only top-level modules, not submodules."""
+        Module.clear_cache()
+
+        sub = temp_dir / "sub"
+        sub.mkdir()
+        for name in ["alpha", "beta"]:
+            mod = {
+                "name": name,
+                "states": {
+                    "Initial": {"type": "Initial", "direct_transition": "Terminal"},
+                    "Terminal": {"type": "Terminal"},
+                },
+            }
+            with open(sub / f"{name}.json", "w") as f:
+                json.dump(mod, f)
+            with open(temp_dir / f"{name}.json", "w") as f:
+                json.dump(mod, f)
+
+        Module._load_json_modules(str(temp_dir))
+        all_mods = Module.get_all_modules()
+
+        # Only top-level modules (no '/' in key) — submodules run via CallSubmodule
+        assert "alpha" in all_mods
+        assert "beta" in all_mods
+        assert "sub/alpha" not in all_mods
+        assert "sub/beta" not in all_mods
+        assert all_mods == sorted(all_mods)
+
+        # But submodules are still reachable by path via get_module
+        assert Module.get_module("sub/alpha") is not None
+        assert Module.get_module("sub/beta") is not None
+
     def test_config_loading_and_override(self, temp_dir):
         """Test configuration loading and override."""
         # Create config file


### PR DESCRIPTION
## Changes

Three related problems in module loading:

**1. Submodule lookup by path failed.** `CallSubmodule` states reference
submodules by relative file path (e.g. `"heart/vhd_risks"`) but modules
were only registered by their JSON `name` field (e.g. `"vhd_risks"`).
Every `CallSubmodule` lookup missed.

**2. Duplicate names caused state corruption.** 6 JSON names are shared
by multiple modules (e.g. `"operation"` is used by both
`heart/cabg/operation.json` and `heart/tavr/operation.json`). The second
one silently overwrote the first, and both modules wrote to the same
patient state-tracking key.

**3. Submodules ran as top-level modules.** `get_all_modules()` returned
all 241 JSON files (including 157 submodules in subdirectories). The
generator iterated all of them on every timestep instead of just the 84
top-level modules. Submodules should only run when called via
`CallSubmodule`.

**Fix:** use the relative file path as the canonical module identity
(matching Java Synthea). `get_all_modules()` returns only top-level
modules (no `/` in path). JSON names are kept as lookup aliases.

Before (10 patients): ~4.4s at 2.3 p/s, zero warnings.
On main (10 patients): hundreds of warnings, submodules running independently.

## Test

```
pytest tests/ --ignore=tests/test_generator.py -v → 25 passed
python -m synthea.cli -p 10 -s 42 -o ./output → 10 FHIR bundles, 0 errors
```

Three new tests:
- `test_submodule_path_resolution` — module in subdirectory reachable by path
- `test_duplicate_module_names` — same JSON name in different dirs → unique identities
- `test_get_all_modules_excludes_submodules` — only top-level modules, sorted, no aliases