### PR TITLE
fix: rename PyPI distribution to tietai-synthea

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/py-synthea
+      url: https://pypi.org/p/tietai-synthea
     permissions:
       id-token: write   # required for OIDC Trusted Publishing
     steps:

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ For a formal description of the framework, design goals, architecture, and gener
 ### From PyPI (recommended)
 
 ```bash
-pip install py-synthea
+pip install tietai-synthea
 ```
 
-The distribution is published as **`py-synthea`**; the import name and CLI
+The distribution is published as **`tietai-synthea`**; the import name and CLI
 command are both `synthea`:
 
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing PySynthea to PyPI
 
-The package is published to **PyPI as [`py-synthea`](https://pypi.org/project/py-synthea/)**
+The package is published to **PyPI as [`tietai-synthea`](https://pypi.org/project/tietai-synthea/)**
 by GitHub Actions using **Trusted Publishing (OIDC)** — no API tokens or secrets
 are stored anywhere. A publish is triggered by **publishing a GitHub Release**.
 
@@ -12,14 +12,14 @@ Workflow: [`.github/workflows/publish.yml`](.github/workflows/publish.yml).
 
 ### 1. Register the Trusted Publisher on PyPI
 
-Because `py-synthea` does not exist on PyPI yet, use the **pending publisher**
+Because `tietai-synthea` does not exist on PyPI yet, use the **pending publisher**
 flow:
 
 1. Log in to PyPI and open <https://pypi.org/manage/account/publishing/>.
 2. Under **"Add a new pending publisher"**, enter exactly:
    | Field | Value |
    |-------|-------|
-   | PyPI Project Name | `py-synthea` |
+   | PyPI Project Name | `tietai-synthea` |
    | Owner | `TIET-AI` |
    | Repository name | `tietai-synthea` |
    | Workflow name | `publish.yml` |
@@ -29,7 +29,7 @@ flow:
    automatically on the first successful publish.
 
 > The account that registers the pending publisher becomes the initial owner of
-> the `py-synthea` project on PyPI.
+> the `tietai-synthea` project on PyPI.
 
 ### 2. Create the `pypi` GitHub Environment
 
@@ -65,10 +65,10 @@ flow:
 
 5. **Verify:**
    ```bash
-   pip install py-synthea==X.Y.Z
+   pip install tietai-synthea==X.Y.Z
    synthea --version
    ```
-   and check <https://pypi.org/project/py-synthea/>.
+   and check <https://pypi.org/project/tietai-synthea/>.
 
 ---
 
@@ -81,6 +81,6 @@ flow:
   second pending publisher on <https://test.pypi.org> with the same values, add
   a `with: repository-url: https://test.pypi.org/legacy/` step to a copy of the
   publish job, and install with
-  `pip install --index-url https://test.pypi.org/simple/ py-synthea`.
+  `pip install --index-url https://test.pypi.org/simple/ tietai-synthea`.
 - The import name and console command remain `synthea`; only the PyPI
-  distribution name is `py-synthea`.
+  distribution name is `tietai-synthea`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=65", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "py-synthea"
+name = "tietai-synthea"
 version = "1.0.0"
 description = "PySynthea - a Python-native synthetic patient population simulator"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2406,96 +2406,6 @@ wheels = [
 ]
 
 [[package]]
-name = "py-synthea"
-version = "1.0.0"
-source = { editable = "." }
-dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "configparser" },
-    { name = "fhir-resources" },
-    { name = "jinja2" },
-    { name = "jsonpath-ng" },
-    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "lxml" },
-    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil" },
-    { name = "pyyaml" },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tqdm" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "black", version = "25.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "black", version = "26.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "flake8" },
-    { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "mypy", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pre-commit", version = "4.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-]
-physiology = [
-    { name = "sympy" },
-]
-visualization = [
-    { name = "graphviz" },
-    { name = "plotly" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=22.0.0" },
-    { name = "click", specifier = ">=8.0.0" },
-    { name = "configparser", specifier = ">=5.0.0" },
-    { name = "fhir-resources", specifier = ">=7.0.0" },
-    { name = "flake8", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "graphviz", marker = "extra == 'visualization'", specifier = ">=0.19" },
-    { name = "jinja2", specifier = ">=3.0.0" },
-    { name = "jsonpath-ng", specifier = ">=1.5.3" },
-    { name = "jsonschema", specifier = ">=4.0.0" },
-    { name = "lxml", specifier = ">=4.6.0" },
-    { name = "matplotlib", specifier = ">=3.5.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=0.950" },
-    { name = "networkx", specifier = ">=2.6.0" },
-    { name = "numpy", specifier = ">=1.21.0" },
-    { name = "pandas", specifier = ">=1.3.0" },
-    { name = "plotly", marker = "extra == 'visualization'", specifier = ">=5.0.0" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=2.15.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.18.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.6.0" },
-    { name = "python-dateutil", specifier = ">=2.8.0" },
-    { name = "pyyaml", specifier = ">=5.4.0" },
-    { name = "requests", specifier = ">=2.26.0" },
-    { name = "scipy", specifier = ">=1.7.0" },
-    { name = "sympy", marker = "extra == 'physiology'", specifier = ">=1.9" },
-    { name = "tqdm", specifier = ">=4.62.0" },
-]
-provides-extras = ["dev", "physiology", "visualization"]
-
-[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3366,6 +3276,96 @@ sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
+
+[[package]]
+name = "tietai-synthea"
+version = "1.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "configparser" },
+    { name = "fhir-resources" },
+    { name = "jinja2" },
+    { name = "jsonpath-ng" },
+    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "lxml" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tqdm" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "black", version = "25.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "black", version = "26.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "flake8" },
+    { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mypy", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pre-commit", version = "4.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+]
+physiology = [
+    { name = "sympy" },
+]
+visualization = [
+    { name = "graphviz" },
+    { name = "plotly" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black", marker = "extra == 'dev'", specifier = ">=22.0.0" },
+    { name = "click", specifier = ">=8.0.0" },
+    { name = "configparser", specifier = ">=5.0.0" },
+    { name = "fhir-resources", specifier = ">=7.0.0" },
+    { name = "flake8", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "graphviz", marker = "extra == 'visualization'", specifier = ">=0.19" },
+    { name = "jinja2", specifier = ">=3.0.0" },
+    { name = "jsonpath-ng", specifier = ">=1.5.3" },
+    { name = "jsonschema", specifier = ">=4.0.0" },
+    { name = "lxml", specifier = ">=4.6.0" },
+    { name = "matplotlib", specifier = ">=3.5.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=0.950" },
+    { name = "networkx", specifier = ">=2.6.0" },
+    { name = "numpy", specifier = ">=1.21.0" },
+    { name = "pandas", specifier = ">=1.3.0" },
+    { name = "plotly", marker = "extra == 'visualization'", specifier = ">=5.0.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=2.15.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.18.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.6.0" },
+    { name = "python-dateutil", specifier = ">=2.8.0" },
+    { name = "pyyaml", specifier = ">=5.4.0" },
+    { name = "requests", specifier = ">=2.26.0" },
+    { name = "scipy", specifier = ">=1.7.0" },
+    { name = "sympy", marker = "extra == 'physiology'", specifier = ">=1.9" },
+    { name = "tqdm", specifier = ">=4.62.0" },
+]
+provides-extras = ["dev", "physiology", "visualization"]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
PyPI rejected `py-synthea` as too similar to the existing `pysynthea` project. Renames the distribution to `tietai-synthea` (import/CLI stay `synthea`). Rebuilt + twine check PASSED; 52 tests pass; 312 resources bundled.