### PR TITLE
fix: honor -o/--output-dir and report correct module count (#21, #22)

### DIFF
--- a/src/synthea/cli.py
+++ b/src/synthea/cli.py
@@ -159,9 +159,8 @@ def main(population, seed, clinician_seed, gender, age, module, config, modules_
     click.echo("")
     
     try:
-        generator = Generator(options)
-        generator.config = config_obj
-        
+        generator = Generator(options, config=config_obj)
+
         # Override modules directory if specified
         if modules_dir:
             Module.load_modules(modules_dir)

--- a/src/synthea/engine/generator.py
+++ b/src/synthea/engine/generator.py
@@ -82,15 +82,20 @@ class GeneratorOptions:
 class Generator:
     """Main generator engine for creating synthetic patients."""
     
-    def __init__(self, options: Optional[GeneratorOptions] = None):
+    def __init__(self, options: Optional[GeneratorOptions] = None,
+                 config: Optional[Config] = None):
         """
         Initialize the generator.
-        
+
         Args:
             options: Configuration options for generation
+            config: A pre-loaded configuration to use (e.g. from the CLI, with
+                overrides such as ``exporter.baseDirectory`` already applied).
+                When omitted, a default config is created and loaded.
         """
         self.options = options or GeneratorOptions()
-        self.config = Config()
+        self.config = config if config is not None else Config()
+        self._config_provided = config is not None
         
         # Initialize random seed if provided
         if self.options.seed is not None:
@@ -120,8 +125,11 @@ class Generator:
     
     def _initialize(self):
         """Initialize all generator components."""
-        # Load configuration
-        self.config.load()
+        # Load configuration. Skip when a pre-configured Config was supplied
+        # (e.g. by the CLI), so caller overrides like exporter.baseDirectory are
+        # preserved and reach the exporter built below.
+        if not self._config_provided:
+            self.config.load()
         
         # Initialize location and demographics
         self._init_location()
@@ -159,11 +167,13 @@ class Generator:
         
         # Load modules from default location
         self.modules = Module.load_modules()
-        
+
         # Get list of modules to use
         self.module_list = self._get_module_list()
-        
-        print(f"Loaded {len(self.modules)} modules")
+
+        # Modules are registered as lazy suppliers, so count the full registry
+        # rather than the materialized dict (which is empty at this point).
+        print(f"Loaded {len(Module.get_all_modules())} modules")
     
     def _get_module_list(self) -> List[str]:
         """Get the list of modules to process for each patient."""

--- a/tests/test_output_and_module_count.py
+++ b/tests/test_output_and_module_count.py
@@ -1,0 +1,42 @@
+"""Regression tests for two generator bugs.
+
+- #21: the ``-o/--output-dir`` override was ignored (output always went to
+  ``./output/``) because the exporter was built from the generator's internal
+  config before the CLI's config was attached.
+- #22: generation logged ``Loaded 0 modules`` because the count was taken from
+  the materialized module dict rather than the (lazily supplied) module set.
+"""
+
+from pathlib import Path
+
+from synthea.engine.generator import Generator, GeneratorOptions
+from synthea.helpers.config import Config
+
+
+def test_output_dir_override_reaches_exporter(tmp_path):
+    """#21: a caller-provided output directory must be used by the exporter."""
+    out = tmp_path / "custom_out"
+    cfg = Config()
+    cfg.load()
+    cfg.set("exporter.baseDirectory", str(out))
+
+    gen = Generator(GeneratorOptions(), config=cfg)
+
+    assert gen.exporter is not None
+    # The exporter must have been built from the provided config's directory...
+    assert Path(gen.exporter.base_dir).resolve() == out.resolve()
+    # ...and the override must not have been clobbered by a config reload.
+    assert gen.config.get("exporter.baseDirectory") == str(out)
+
+
+def test_generator_reports_loaded_module_count(tmp_path, capsys):
+    """#22: the 'Loaded N modules' log must reflect the real count, not 0."""
+    cfg = Config()
+    cfg.load()
+    cfg.set("exporter.baseDirectory", str(tmp_path / "out"))
+
+    Generator(GeneratorOptions(), config=cfg)
+
+    out = capsys.readouterr().out
+    assert "Loading modules..." in out
+    assert "Loaded 0 modules" not in out


### PR DESCRIPTION
## Summary
Fixes two generator bugs found during the 1.0.0 packaging work.

### #21 — `-o/--output-dir` was ignored (output always `./output/`)
`Generator.__init__` built its `Exporter` from an internal `Config` during
construction, but `cli.py` only attached the configured `Config`
(`generator.config = config_obj`) *afterward* — too late, since the exporter had
already captured `baseDirectory` (and `mkdir`'d `./output`).

**Fix:** add an optional `config=` parameter to `Generator`, and pass the CLI's
config (with `exporter.baseDirectory` already set) into the constructor. Skip the
redundant `self.config.load()` in `_initialize()` when a config is supplied, so
the override isn't clobbered. Backward compatible — all existing `Generator(options)`
call sites are unaffected.

### #22 — `Loaded 0 modules` log
`_load_modules()` logged `len(self.modules)` (the materialized dict, empty because
modules register as lazy suppliers). Now logs `len(Module.get_all_modules())`.

## Verification
- New `tests/test_output_and_module_count.py` (both scenarios) — fail before, pass after.
- Full suite: **54 passed**.
- End-to-end: `synthea -p 2 -o ./chosen` from an empty dir → 2 FHIR bundles in
  `./chosen/fhir/`, **0** in `./output/`; log now reads `Loaded 99 modules`.

Closes #21
Closes #22
