### PR TITLE
chore: release 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tietai-synthea"
-version = "1.0.0"
+version = "1.0.1"
 description = "PySynthea - a Python-native synthetic patient population simulator"
 readme = "README.md"
 requires-python = ">=3.9,<3.14"

--- a/src/synthea/__init__.py
+++ b/src/synthea/__init__.py
@@ -5,7 +5,7 @@ A Python implementation of the Synthea patient generator, which creates
 synthetic, realistic (but not real) patient data and associated health records.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __author__ = "TietAI and PySynthea project contributors"
 
 from synthea.engine.generator import Generator

--- a/uv.lock
+++ b/uv.lock
@@ -3279,7 +3279,7 @@ wheels = [
 
 [[package]]
 name = "tietai-synthea"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Version bump 1.0.0 -> 1.0.1. Ships the #21 (`-o` output dir) and #22 (module count) fixes. twine check PASSED; wheel is `tietai_synthea-1.0.1`.